### PR TITLE
Fix \setmathdigitfont

### DIFF
--- a/xepersian.dtx
+++ b/xepersian.dtx
@@ -5952,7 +5952,7 @@ indexblock environment may only appear inside frontpage environment.
 
 \prg_new_conditional:Nnn \__xepersian_mathsdigitspec_primitive_font_char_if_exist:n {p,TF,T,F}
   {
-    \etex_iffontchar:D \l_fontspec_font "#1 \scan_stop:
+    \tex_iffontchar:D \l_fontspec_font "#1 \scan_stop:
       \prg_return_true:
     \else:
       \prg_return_false:


### PR DESCRIPTION
fix https://github.com/persiantex/xepersian/issues/17
ref https://github.com/firamath/firamath/commit/88c9c6c344ac8f13d6f758b579a3039c7e01c9bd

---
name: Pull request
about: fix `\setmathdigitfont` command
title: 'Fix `\setmathdigitfont`'
labels: pull
assignees: vafakhalighi

---

---

<!---
!! Please fill out all sections !!
-->

## Status

**READY**

## Description

See https://github.com/persiantex/xepersian/issues/17.

## Todos
- [x] Relevant to the `xepersian` package
- [x] [The `xepersian` package issue tracker](https://github.com/persiantex/xepersian/issues) has been searched for similar issues?
- [x] Issue tracker has been searched for similar issues?
- [ ] Links to <tex.stackexchange.com> discussion if appropriate
- [ ] Links to <qa.parsilatex.com> discussion if appropriate
- [ ] Tests added to cover new/fixed functionality
- [ ] Documentation if necessary

## Minimal example showing the new/fixed functionality


```tex
\documentclass{article}

\usepackage{xepersian}
\settextfont{Yas}
\setmathdigitfont{Yas}

\begin{document}
سلام این یک متن آزمایشی با عدد ۰۱۲۳۴۵۶۷۸۹ است. 
\end{document}
```

## Expected behavior

See https://github.com/persiantex/xepersian/issues/17.

## Log and PDF files 

See https://github.com/persiantex/xepersian/issues/17.

<!---
!! Use drag-and-drop !!
-->
